### PR TITLE
Add PHPUnit workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,26 @@
+name: PHPUnit
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: actions/setup-php@v3
+        with:
+          php-version: '8.1'
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Continuous Integration
+
+This project uses GitHub Actions to automatically run the PHPUnit test suite. The workflow at `.github/workflows/phpunit.yml` sets up PHP, caches Composer dependencies, installs them, and runs `phpunit`.


### PR DESCRIPTION
## Summary
- add GitHub Action workflow to run PHPUnit
- document workflow in the README

## Testing
- `composer install --prefer-dist --no-interaction` *(fails: composer not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683fa463598c832aace2c034ab631aa5